### PR TITLE
Fix AppVeyor tests

### DIFF
--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -94,7 +94,6 @@ namespace ImageViewer.Tests
             var receiver = new Mock<IReceiveImage>();
             receiver
                 .Setup(r => r.ReceiveImage(It.IsAny<ImageMeta>()))
-                .Callback(() => Console.WriteLine($"Receiver called!"))
                 .Verifiable();
 
             var slowLoader = GetLoader(50);
@@ -113,9 +112,7 @@ namespace ImageViewer.Tests
             var loader = new Mock<IImageLoader>();
             loader.Setup(l => l.LoadImage(It.IsAny<string>())).Returns(() =>
               {
-                  Console.WriteLine($"ImageLoader of {delay}ms starting");
                   Task.Delay(delay).Wait();
-                  Console.WriteLine($"ImageLoader of {delay} done");
                   return new ImageMeta();
               });
             return loader;

--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -92,6 +92,11 @@ namespace ImageViewer.Tests
         public async Task TwoStepImageCache_ReceivesOnceWithFastLoader()
         {
             var receiver = new Mock<IReceiveImage>();
+            receiver
+                .Setup(r => r.ReceiveImage(It.IsAny<ImageMeta>()))
+                .Callback(() => Console.WriteLine($"Receiver called!"))
+                .Verifiable();
+
             var slowLoader = GetLoader(50);
             var fastLoader = GetLoader(500);
 
@@ -108,7 +113,9 @@ namespace ImageViewer.Tests
             var loader = new Mock<IImageLoader>();
             loader.Setup(l => l.LoadImage(It.IsAny<string>())).Returns(() =>
               {
+                  Console.WriteLine($"ImageLoader of {delay}ms starting");
                   Task.Delay(delay).Wait();
+                  Console.WriteLine($"ImageLoader of {delay} done");
                   return new ImageMeta();
               });
             return loader;

--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -96,12 +96,9 @@ namespace ImageViewer.Tests
             var fastLoader = GetLoader(500);
 
             TwoStepImageCache cache = new TwoStepImageCache(slowLoader.Object, fastLoader.Object, receiver.Object, 1);
-            cache.LoadImage("test.png");
+            await cache.LoadImageAsync("test.png");
 
             await Task.Delay(600);
-
-            slowLoader.Verify(l => l.LoadImage(It.IsAny<string>()), Times.Once());
-            fastLoader.Verify(l => l.LoadImage(It.IsAny<string>()), Times.Once());
 
             receiver.Verify(r => r.ReceiveImage(It.IsAny<ImageMeta>()), Times.Once);
         }

--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -93,12 +93,12 @@ namespace ImageViewer.Tests
         {
             var receiver = new Mock<IReceiveImage>();
             var slowLoader = GetLoader(50);
-            var fastLoader = GetLoader(100);
+            var fastLoader = GetLoader(500);
 
             TwoStepImageCache cache = new TwoStepImageCache(slowLoader.Object, fastLoader.Object, receiver.Object, 1);
             cache.LoadImage("test.png");
 
-            await Task.Delay(200);
+            await Task.Delay(600);
 
             slowLoader.Verify(l => l.LoadImage(It.IsAny<string>()), Times.Once());
             fastLoader.Verify(l => l.LoadImage(It.IsAny<string>()), Times.Once());

--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -74,6 +74,10 @@ namespace ImageViewer.Tests
         public async Task TwoStepImageCache_ReceivesTwiceWithSlowLoader()
         {
             var receiver = new Mock<IReceiveImage>();
+            receiver
+                .Setup(r => r.ReceiveImage(It.IsAny<ImageMeta>()))
+                .Verifiable();
+
             var slowLoader = GetLoader(100);
             var fastLoader = GetLoader(50);
             

--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -71,7 +71,7 @@ namespace ImageViewer.Tests
         }
 
         [Test]
-        public async Task TwoStepImageCache_ReceivesTwiceWithSlowLoader()
+        public void TwoStepImageCache_ReceivesTwiceWithSlowLoader()
         {
             var receiver = new Mock<IReceiveImage>();
             receiver
@@ -85,7 +85,7 @@ namespace ImageViewer.Tests
             TwoStepImageCache cache = new TwoStepImageCache(slowLoader.Object, fastLoader.Object, receiver.Object, 1);
             cache.LoadImage("test.png");
 
-            await Task.Delay(200);
+            Task.Delay(200).Wait();
 
             slowLoader.Verify(l => l.LoadImage(It.IsAny<string>()), Times.Once());
             fastLoader.Verify(l => l.LoadImage(It.IsAny<string>()), Times.Once());
@@ -94,7 +94,7 @@ namespace ImageViewer.Tests
         }
 
         [Test]
-        public async Task TwoStepImageCache_ReceivesOnceWithFastLoader()
+        public void TwoStepImageCache_ReceivesOnceWithFastLoader()
         {
             var receiver = new Mock<IReceiveImage>();
             receiver
@@ -102,13 +102,13 @@ namespace ImageViewer.Tests
                 .Callback(() => Console.WriteLine("Receive"))
                 .Verifiable();
 
-            var slowLoader = GetLoader(50);
-            var fastLoader = GetLoader(500);
+            var slowLoader = GetLoader(20);
+            var fastLoader = GetLoader(300);
 
             TwoStepImageCache cache = new TwoStepImageCache(slowLoader.Object, fastLoader.Object, receiver.Object, 1);
-            await cache.LoadImageAsync("test.png");
+            cache.LoadImage("test.png");
 
-            await Task.Delay(600);
+            Task.Delay(400).Wait();
 
             receiver.Verify(r => r.ReceiveImage(It.IsAny<ImageMeta>()), Times.Once);
         }

--- a/ImageViewer.Tests/ImageCacheTests.cs
+++ b/ImageViewer.Tests/ImageCacheTests.cs
@@ -76,6 +76,7 @@ namespace ImageViewer.Tests
             var receiver = new Mock<IReceiveImage>();
             receiver
                 .Setup(r => r.ReceiveImage(It.IsAny<ImageMeta>()))
+                .Callback(()=>Console.WriteLine("Receive"))
                 .Verifiable();
 
             var slowLoader = GetLoader(100);
@@ -98,6 +99,7 @@ namespace ImageViewer.Tests
             var receiver = new Mock<IReceiveImage>();
             receiver
                 .Setup(r => r.ReceiveImage(It.IsAny<ImageMeta>()))
+                .Callback(() => Console.WriteLine("Receive"))
                 .Verifiable();
 
             var slowLoader = GetLoader(50);

--- a/ImageViewer.Tests/ImageViewer.Tests.csproj
+++ b/ImageViewer.Tests/ImageViewer.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />


### PR DESCRIPTION
The test: TwoStepImageCache_ReceivesOnceWithFastLoader works fine locally but fails on appveyor.
Probably because the build agent is slower than the local machine.
